### PR TITLE
Replace hook

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,17 +1,17 @@
 pkgbase = nvidia-container-toolkit
 	pkgdesc = NVIDIA container runtime toolkit
 	pkgver = 1.0.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/NVIDIA/nvidia-container-runtime
 	arch = x86_64
 	license = BSD
 	makedepends = go
 	depends = libnvidia-container-tools
 	depends = docker>=1:19.03
-	provides = nvidia-container-runtime-hook
 	conflicts = nvidia-docker
 	conflicts = nvidia-container-runtime-hook
 	conflicts = nvidia-container-runtime<2.0.0
+	replaces = nvidia-container-runtime-hook
 	source = https://github.com/NVIDIA/nvidia-container-runtime/archive/3.1.0.tar.gz
 	sha256sums = 9fd1fd6d39e02b1e1cd41219cf8b2e657a4f3c4fad36ee94b397fff0cb9a0865
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=nvidia-container-toolkit
 pkgver=1.0.1
 _runtime_pkgver=3.1.0
 
-pkgrel=1
+pkgrel=2
 pkgdesc='NVIDIA container runtime toolkit'
 arch=('x86_64')
 url='https://github.com/NVIDIA/nvidia-container-runtime'
@@ -15,7 +15,7 @@ license=('BSD')
 makedepends=('go')
 depends=('libnvidia-container-tools' 'docker>=1:19.03')
 conflicts=('nvidia-docker' 'nvidia-container-runtime-hook' 'nvidia-container-runtime<2.0.0')
-provides=('nvidia-container-runtime-hook')
+replaces=('nvidia-container-runtime-hook')
 
 source=("https://github.com/NVIDIA/nvidia-container-runtime/archive/${_runtime_pkgver}.tar.gz")
 sha256sums=('9fd1fd6d39e02b1e1cd41219cf8b2e657a4f3c4fad36ee94b397fff0cb9a0865')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -34,7 +34,7 @@ build() {
 package() {
   install -D -m755 "${srcdir}/gopath/bin/${pkgname}" "$pkgdir/usr/bin/${pkgname}"
   pushd "$pkgdir/usr/bin/"
-  ln -sf "$pkgdir/usr/bin/${pkgname}" "$pkgdir/usr/bin/nvidia-container-runtime-hook"
+  ln -sf "${pkgname}" "nvidia-container-runtime-hook"
   popd
   install -D -m644 "${_srcdir}/toolkit/config.toml.centos" "$pkgdir/etc/nvidia-container-runtime/config.toml"
   install -D -m755 "${_srcdir}/toolkit/oci-nvidia-hook" "$pkgdir/usr/libexec/oci/hooks.d/oci-nvidia-hook"


### PR DESCRIPTION
- This should replaces `nvidia-container-runtime-hook`, not provides since `nvidia-container-runtime-hook` is now obsolete.

- Also fix `namcap` error caused by symlinking absolute `pkgdir` path
```
nvidia-container-toolkit E: Symlink (usr/bin/nvidia-container-runtime-hook) points to non-existing /<absolute>/<path>/<to>/<build-time>/pkg/nvidia-container-toolkit/usr/bin/nvidia-container-toolkit
```

- Pump `pkgrel`