### PR TITLE
Remove nvidia-docker conflict

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,13 @@
 pkgbase = nvidia-container-toolkit
 	pkgdesc = NVIDIA container runtime toolkit
 	pkgver = 1.0.1
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/NVIDIA/nvidia-container-runtime
 	arch = x86_64
 	license = BSD
 	makedepends = go
 	depends = libnvidia-container-tools
 	depends = docker>=1:19.03
-	conflicts = nvidia-docker
 	conflicts = nvidia-container-runtime-hook
 	conflicts = nvidia-container-runtime<2.0.0
 	replaces = nvidia-container-runtime-hook

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=nvidia-container-toolkit
 pkgver=1.0.1
 _runtime_pkgver=3.1.0
 
-pkgrel=3
+pkgrel=4
 pkgdesc='NVIDIA container runtime toolkit'
 arch=('x86_64')
 url='https://github.com/NVIDIA/nvidia-container-runtime'
@@ -14,7 +14,7 @@ license=('BSD')
 
 makedepends=('go')
 depends=('libnvidia-container-tools' 'docker>=1:19.03')
-conflicts=('nvidia-docker' 'nvidia-container-runtime-hook' 'nvidia-container-runtime<2.0.0')
+conflicts=('nvidia-container-runtime-hook' 'nvidia-container-runtime<2.0.0')
 replaces=('nvidia-container-runtime-hook')
 
 source=("https://github.com/NVIDIA/nvidia-container-runtime/archive/${_runtime_pkgver}.tar.gz")


### PR DESCRIPTION
This doesn't conflict with `nvidia-docker` though. In fact now `nvidia-docker` depends on `nvidia-container-runtime` which in turns depends on this.