### PR TITLE
Remove oci-nvidia-hook

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = nvidia-container-toolkit
 	pkgdesc = NVIDIA container runtime toolkit
 	pkgver = 1.0.1
-	pkgrel = 4
+	pkgrel = 5
 	url = https://github.com/NVIDIA/nvidia-container-runtime
 	arch = x86_64
 	license = BSD

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=nvidia-container-toolkit
 pkgver=1.0.1
 _runtime_pkgver=3.1.0
 
-pkgrel=4
+pkgrel=5
 pkgdesc='NVIDIA container runtime toolkit'
 arch=('x86_64')
 url='https://github.com/NVIDIA/nvidia-container-runtime'
@@ -43,8 +43,6 @@ package() {
   ln -sf "${pkgname}" "nvidia-container-runtime-hook"
   popd
   install -D -m644 "${_srcdir}/toolkit/config.toml.centos" "$pkgdir/etc/nvidia-container-runtime/config.toml"
-  install -D -m755 "${_srcdir}/toolkit/oci-nvidia-hook" "$pkgdir/usr/libexec/oci/hooks.d/oci-nvidia-hook"
-  install -D -m644 "${_srcdir}/toolkit/oci-nvidia-hook.json" "$pkgdir/usr/share/containers/oci/hooks.d/oci-nvidia-hook.json"
 
   install -D -m644 "${_srcdir}/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
`oci-nvidia-hook` is only need for CentOS using [Red Hat's fork of Docker](https://github.com/projectatomic/docker). See [here](https://github.com/NVIDIA/nvidia-container-runtime/blob/dc6b7dff057f34337b4a49061c84984d66054bfe/toolkit/Dockerfile.centos#L23).