### PR TITLE
1.0.3

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = nvidia-container-toolkit
 	pkgdesc = NVIDIA container runtime toolkit
-	pkgver = 1.0.1
-	pkgrel = 5
+	pkgver = 1.0.3
+	pkgrel = 1
 	url = https://github.com/NVIDIA/nvidia-container-runtime
 	arch = x86_64
 	license = BSD
@@ -11,8 +11,8 @@ pkgbase = nvidia-container-toolkit
 	conflicts = nvidia-container-runtime-hook
 	conflicts = nvidia-container-runtime<2.0.0
 	replaces = nvidia-container-runtime-hook
-	source = https://github.com/NVIDIA/nvidia-container-runtime/archive/3.1.0.tar.gz
-	sha256sums = 9fd1fd6d39e02b1e1cd41219cf8b2e657a4f3c4fad36ee94b397fff0cb9a0865
+	source = https://github.com/NVIDIA/nvidia-container-runtime/archive/v3.1.2.tar.gz
+	sha256sums = ccc2f60ae46765c9529b1c419365445d56e939d6bbbabd755d3c6175d7d22dc5
 
 pkgname = nvidia-container-toolkit
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 src/
 pkg/
 
+nvidia-container-runtime/
 nvidia-container-runtime-hook/
 runc/

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,10 +3,10 @@
 
 pkgname=nvidia-container-toolkit
 
-pkgver=1.0.1
-_runtime_pkgver=3.1.0
+pkgver=1.0.3
+_runtime_pkgver=3.1.2
 
-pkgrel=5
+pkgrel=1
 pkgdesc='NVIDIA container runtime toolkit'
 arch=('x86_64')
 url='https://github.com/NVIDIA/nvidia-container-runtime'
@@ -17,8 +17,8 @@ depends=('libnvidia-container-tools' 'docker>=1:19.03')
 conflicts=('nvidia-container-runtime-hook' 'nvidia-container-runtime<2.0.0')
 replaces=('nvidia-container-runtime-hook')
 
-source=("https://github.com/NVIDIA/nvidia-container-runtime/archive/${_runtime_pkgver}.tar.gz")
-sha256sums=('9fd1fd6d39e02b1e1cd41219cf8b2e657a4f3c4fad36ee94b397fff0cb9a0865')
+source=("https://github.com/NVIDIA/nvidia-container-runtime/archive/v${_runtime_pkgver}.tar.gz")
+sha256sums=('ccc2f60ae46765c9529b1c419365445d56e939d6bbbabd755d3c6175d7d22dc5')
 
 _srcdir="nvidia-container-runtime-${_runtime_pkgver}"
 


### PR DESCRIPTION
New versions of toolkit, runtime and nvidia-docker have been released for Ubuntu and CentOS. Just that no github releases this time so revert to using git commits as source. Everything has been tested on my machine.

Could help me take a look at then merge
jshap70/aur-nvidia-docker#1
kiendang/aur-nvidia-container-runtime#4
kiendang/aur-nvidia-container-runtime-bin#3
as well?

Thanks!

PS: I'm thinking of moving all these repos to an org for easier access lol like aur-nvidia-container-tools or smt what do you think?